### PR TITLE
add Dmn_Kafka wrapper of Dmn_Io interface to Kafka low level C++ 

### DIFF
--- a/Dmn/CMakeLists.txt
+++ b/Dmn/CMakeLists.txt
@@ -56,6 +56,10 @@ add_library(dmn
               ${CMAKE_CURRENT_SOURCE_DIR}/dmn-proc.cpp
               ${CMAKE_CURRENT_SOURCE_DIR}/dmn-socket.cpp
 
+              # kafka
+              ${CMAKE_CURRENT_SOURCE_DIR}/kafka/dmn-kafka-util.cpp
+              ${CMAKE_CURRENT_SOURCE_DIR}/kafka/dmn-kafka.cpp
+
               # proto c++ sources
               ${CMAKE_CURRENT_SOURCE_DIR}/proto/dmn-dmesg-body.pb.cc
               ${CMAKE_CURRENT_SOURCE_DIR}/proto/dmn-dmesg-type.pb.cc
@@ -86,8 +90,10 @@ target_sources(dmn
                  ${CMAKE_CURRENT_SOURCE_DIR}/dmn-singleton.hpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/dmn-socket.hpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/dmn-teepipe.hpp
-                 ${CMAKE_CURRENT_SOURCE_DIR}/dmn-timer.hpp
-                 ${CMAKE_CURRENT_SOURCE_DIR}/dmn-util.hpp
+
+                 # kafka
+                 ${CMAKE_CURRENT_SOURCE_DIR}/kafka/dmn-kafka-util.hpp
+                 ${CMAKE_CURRENT_SOURCE_DIR}/kafka/dmn-kafka.hpp
 
                  # proto c++ sources
                  ${CMAKE_CURRENT_SOURCE_DIR}/proto/dmn-dmesg-body.pb.h
@@ -105,6 +111,7 @@ target_include_directories(dmn
 
 target_include_directories(dmn
                              PRIVATE
+                             ${rdkafka_INCLUDE}
 )
 
 GENERATE_PROTOBUF(dmn

--- a/Dmn/dmn-kafka-sender.cpp
+++ b/Dmn/dmn-kafka-sender.cpp
@@ -25,6 +25,8 @@ static void dr_msg_cb(rd_kafka_t *kafka_handle,
   if (rkmessage->err) {
     std::cerr << "Message delivery failed: " << rd_kafka_err2str(rkmessage->err)
               << "\n";
+  } else {
+    std::cerr << "Message delivery success\n";
   }
 }
 

--- a/Dmn/kafka/dmn-kafka.cpp
+++ b/Dmn/kafka/dmn-kafka.cpp
@@ -1,0 +1,131 @@
+/**
+ * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ */
+
+#include "dmn-kafka.hpp"
+#include "dmn-kafka-util.hpp"
+
+#include "rdkafka.h"
+
+#include <cassert>
+#include <exception>
+#include <expected>
+#include <iostream>
+#include <functional>
+#include <string>
+
+namespace Dmn {
+  const std::string Dmn_Kafka::Topic = "Dmn_Kafka.Topic";
+  const std::string Dmn_Kafka::Key = "Dmn_Kafka.Key";
+
+  void Dmn_Kafka::kafkaCallback(rd_kafka_t *kafka_handle,
+                                const rd_kafka_message_t *rkmessage, void *opaque) {
+    Dmn_Kafka *obj = (Dmn_Kafka *)opaque;
+
+    if (rkmessage->err) {
+      obj->m_kafkaErr = rkmessage->err;
+    }
+
+    obj->m_atomicFlag.clear();
+    obj->m_atomicFlag.notify_all();
+  }
+
+  Dmn_Kafka::Dmn_Kafka(Dmn_Kafka::Role role, Dmn_Kafka::ConfigType configs) : m_role{role}, m_configs{configs}{
+    // create kafka configuration
+    m_kafkaConf = rd_kafka_conf_new();
+
+    for (auto & c : m_configs) {
+       if (Dmn_Kafka::Topic == c.first) {
+         m_topic = c.second;
+
+         continue;
+       }
+
+       if (Dmn_Kafka::Key == c.first) {
+         m_topic = c.second;
+
+         continue;
+       }
+
+       auto res = Dmn::set_config(m_kafkaConf, c.first.c_str(), c.second.c_str());
+       if (!res.has_value()) {
+         throw std::runtime_error("Error in setting kafka configuration: "
+                                  + c.first + " to value: " + c.second);
+       }
+
+       assert(res.value() == RD_KAFKA_CONF_OK);
+    }
+
+    rd_kafka_conf_set_dr_msg_cb(m_kafkaConf, Dmn_Kafka::kafkaCallback);
+    rd_kafka_conf_set_opaque(m_kafkaConf, (void *)this);
+
+    // Create the Producer instance.
+    char errstr[512];
+    m_kafka = rd_kafka_new(RD_KAFKA_PRODUCER, m_kafkaConf, errstr, sizeof(errstr));
+    if (!m_kafka) {
+       throw std::runtime_error("Failed to create new producer: " + std::string(errstr));
+    }
+
+    // Configuration object is now owned, and freed, by the rd_kafka_t instance.
+    m_kafkaConf = NULL;
+  }
+
+  Dmn_Kafka::~Dmn_Kafka() noexcept try {
+
+    if (m_kafkaConf) {
+      rd_kafka_conf_destroy(m_kafkaConf);
+    }
+
+    if (m_kafka) {
+      rd_kafka_flush(m_kafka, 10 * 1000);
+
+      rd_kafka_destroy(m_kafka);
+    }
+  } catch (...) {
+    // explicit return to resolve exception as destructor must be noexcept
+    return;
+  }
+
+  std::optional<std::string> Dmn_Kafka::read() {
+    return {};
+  }
+
+  void Dmn_Kafka::write(std::string &item) {
+    write(item, false);
+  }
+
+  void Dmn_Kafka::write(std::string &&item) {
+    write(item, true);
+  }
+
+  void Dmn_Kafka::write(std::string &item, bool move) {
+    while (m_atomicFlag.test_and_set(std::memory_order_acquire))
+      m_atomicFlag.wait(true, std::memory_order_relaxed);
+
+    const char *topic = m_topic.c_str();
+    const char *key = m_key.c_str();
+    const size_t keyLen = m_key.size();
+    const char *value = item.c_str();
+    const size_t valueLen = item.size();
+
+    rd_kafka_resp_err_t err = rd_kafka_producev(m_kafka, RD_KAFKA_V_TOPIC(topic),
+                                                RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
+                                                RD_KAFKA_V_KEY((void *)key, keyLen),
+                                                RD_KAFKA_V_VALUE((void *)value, valueLen),
+                                                RD_KAFKA_V_OPAQUE(NULL),
+                                                RD_KAFKA_V_END);
+
+    if (err) {
+      throw std::runtime_error("Failed to produce to topic: " + m_topic + ", error: " + std::string(rd_kafka_err2str(err)));
+    }
+
+    rd_kafka_poll(m_kafka, 0);
+    rd_kafka_flush(m_kafka, 10 * 1000);
+
+    m_atomicFlag.wait(true);
+    if (m_kafkaErr) {
+      throw std::runtime_error("Failed to delivered to topic: " + m_topic + ", error: " + std::string(rd_kafka_err2str(m_kafkaErr)));
+    }
+  }
+}
+

--- a/Dmn/kafka/dmn-kafka.hpp
+++ b/Dmn/kafka/dmn-kafka.hpp
@@ -1,0 +1,78 @@
+/**
+ * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ */
+
+#ifndef DMN_KAFKA_HPP_HAVE_SEEN
+
+#define DMN_KAFKA_HPP_HAVE_SEEN
+
+#include "dmn-io.hpp"
+#include "dmn-kafka-util.hpp"
+
+#include "rdkafka.h"
+
+#include <atomic>
+#include <expected>
+#include <functional>
+#include <map>
+#include <string>
+
+namespace Dmn {
+
+class Dmn_Kafka : public Dmn::Dmn_Io<std::string> {
+public:
+  const static std::string Topic;
+  const static std::string Key;
+
+  using ConfigType = std::map<std::string, std::string>;
+
+  enum class Role {
+    Consumer = 0,
+    Producer = 0
+  };
+
+  Dmn_Kafka(Role role, ConfigType configs = {});
+
+  ~Dmn_Kafka() noexcept;
+
+  Dmn_Kafka(const Dmn_Kafka &dmnDMesgHandlerSub) = delete;
+  const Dmn_Kafka & operator=(const Dmn_Kafka &dmnDMesgHandlerSub) = delete;
+  Dmn_Kafka(Dmn_Kafka &&dmnDMesgHandlerSub) = delete;
+  Dmn_Kafka & operator=(Dmn_Kafka &&dmnDMesgHandlerSub) = delete;
+
+  std::optional<std::string> read() override;
+  void write(std::string &item) override;
+  void write(std::string &&item) override;
+
+  static void kafkaCallback(rd_kafka_t *kafka_handle,
+                            const rd_kafka_message_t *rkmessage,
+                            void *opaque);
+
+private:
+  void write(std::string &item, bool move);
+
+  /**
+   * data members for constructor to instantiate the object.
+   */
+  Role       m_role{};
+  ConfigType m_configs{};
+
+  /**
+   * data members for internal logic.
+   */
+  std::string m_key{};
+  std::string m_topic{};
+
+  rd_kafka_t *m_kafka{};
+  rd_kafka_conf_t *m_kafkaConf{};
+  rd_kafka_resp_err_t m_kafkaErr{};
+
+  std::atomic_flag m_atomicFlag{};
+};
+
+} /* namespace Dmn */
+
+#endif /* DMN_KAFKA_HPP_HAVE_SEEN */
+
+
+

--- a/Dmn/test/CMakeLists.txt
+++ b/Dmn/test/CMakeLists.txt
@@ -23,6 +23,7 @@ ADD_TEST_EXECUTABLE(dmn
                       dmn-test-dmesg-pb
                       dmn-test-dmesg-pb-util
                       dmn-test-io
+                      dmn-test-kafka
                       dmn-test-pipe
                       dmn-test-pub-sub
                       dmn-test-singleton

--- a/Dmn/test/dmn-test-kafka.cpp
+++ b/Dmn/test/dmn-test-kafka.cpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright © 2025 Chee Bin HOH. All rights reserved.
+ */
+
+#include "kafka/dmn-kafka.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  Dmn::Dmn_Kafka::ConfigType configs{};
+  configs["bootstrap.servers"] = "pkc-619z3.us-east1.gcp.confluent.cloud:9092";
+  configs["sasl.username"] = "C3T2TGVAQYYF7H6T";
+  configs["sasl.password"] = "4JNbCdwNsK6HSgj65AHdZT5d9VsyWPX+lQysSPca70ehKN7uHsCuIyPlHw32gmNr";
+  configs["security.protocol"] = "SASL_SSL";
+  configs["sasl.mechanisms"] = "PLAIN";
+  configs["acks"] = "all";
+  configs[Dmn::Dmn_Kafka::Topic] = "timer_counter";
+  configs[Dmn::Dmn_Kafka::Key] = "tick";
+
+  Dmn::Dmn_Kafka producer{Dmn::Dmn_Kafka::Role::Producer, configs};
+ 
+  producer.write("heartbeat : test 1");
+ 
+  return RUN_ALL_TESTS();
+}

--- a/pull-from-git.sh
+++ b/pull-from-git.sh
@@ -5,4 +5,4 @@
 # A shell script to pull and fetch from master
 
 git fetch .
-git pull origin ${1:-"master"}
+git pull origin `git branch  | grep '^*'  | sed -e 's/\*//g'`

--- a/push-to-git.sh
+++ b/push-to-git.sh
@@ -104,7 +104,7 @@ echo
 
 git add .
 git commit -m "${1:-"no comment"}"
-git push origin master --force
+git push origin `git branch  | grep '^*'  | sed -e 's/\*//g'` --force
 
 
 if [ $rootdir != "" ]; then


### PR DESCRIPTION
In this PR, we create a new Dmn_Kafka class that inherits from Hal_Io read/write interface, and stuff it with Kafka C++ low level interface. 

This is part one of step 1 to allow us to send Dmn_DMesgNet message across Kafka cloud. 